### PR TITLE
Don't allow using 'source' in files

### DIFF
--- a/pkg/linuxkit/build.go
+++ b/pkg/linuxkit/build.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ernoaapa/linuxkit-server/pkg/validation"
 	"github.com/moby/tool/src/moby"
 	"github.com/pkg/errors"
 )
@@ -13,6 +14,10 @@ import (
 func Build(name string, config []byte, formats []string, targetDir string) (err error) {
 	c, err := moby.NewConfig(config)
 	if err != nil {
+		return NewErrInvalidConfiguration(err.Error())
+	}
+
+	if err := validation.IsValid(c); err != nil {
 		return NewErrInvalidConfiguration(err.Error())
 	}
 

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -1,0 +1,20 @@
+package validation
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/moby/tool/src/moby"
+)
+
+// IsValid validates the Linuxkit configuration and
+// return nil if valid or error if some error found
+func IsValid(c moby.Moby) error {
+	for index, file := range c.Files {
+		log.Println(file)
+		if file.Source != "" {
+			return fmt.Errorf("Invalid configuration in 'files[%d].source'. You cannot use file source when building in remote build server", index)
+		}
+	}
+	return nil
+}

--- a/pkg/validation/validate_test.go
+++ b/pkg/validation/validate_test.go
@@ -1,0 +1,44 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/moby/tool/src/moby"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValid(t *testing.T) {
+	minimalYaml := `
+kernel:
+  image: linuxkit/kernel:4.9.69
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+files:
+  - path: /etc/issue
+    contents: "wellcome to EliotOS"
+trust:
+  org:
+    - linuxkit`
+	c, parseErr := moby.NewConfig([]byte(minimalYaml))
+	assert.NoError(t, parseErr)
+
+	err := IsValid(c)
+	assert.NoError(t, err)
+}
+
+func TestIsValidReturnErrorIfRelativeFiles(t *testing.T) {
+	yamlWithFiles := `
+kernel:
+  image: linuxkit/kernel:4.9.69
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+files:
+  - path: /etc/issue
+    source: "/some/path/in/the/server"
+trust:
+  org:
+    - linuxkit`
+	c, parseErr := moby.NewConfig([]byte(yamlWithFiles))
+	assert.NoError(t, parseErr)
+
+	err := IsValid(c)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
With linuxkit-server, building happens in the remote server.
Linuxkit supports having file 'source' which reads the file to
get file source.
This causes security risk because it allows reading and including
files into the final image from the server where linuxkit-server
is running.
For now blocked totally using 'source'.